### PR TITLE
Improved 'Import Putty Sessions' and 'Duplicate Session' features

### DIFF
--- a/SuperPutty/SessionData.cs
+++ b/SuperPutty/SessionData.cs
@@ -126,6 +126,18 @@ namespace SuperPutty
             Proto = protocol;
             PuttySession = sessionConfig;
         }
+
+        public SessionData(SessionData data)
+        {
+            SessionName = data.SessionName;
+            Host = data.Host;
+            Port = data.Port;
+            Proto = data.Proto;
+            PuttySession = data.PuttySession;
+            Username = data.Username;
+            LastDockstate = data.LastDockstate;
+            AutoStartSession = data.AutoStartSession;
+        }
         
         public SessionData()
         {

--- a/SuperPutty/SessionTreeview.cs
+++ b/SuperPutty/SessionTreeview.cs
@@ -39,6 +39,7 @@ namespace SuperPutty
     public partial class SessionTreeview : ToolWindow
     {
         private DockPanel m_DockPanel;
+        private frmSuperPutty m_SuperPutty;
 
         /// <summary>
         /// Instantiate the treeview containing the sessions
@@ -46,9 +47,10 @@ namespace SuperPutty
         /// <param name="dockPanel">The DockPanel container</param>
         /// <remarks>Having the dockpanel container is necessary to allow us to
         /// dock any terminal or file transfer sessions from within the treeview class</remarks>
-        public SessionTreeview(DockPanel dockPanel)
+        public SessionTreeview(frmSuperPutty superPutty, DockPanel dockPanel)
         {
             m_DockPanel = dockPanel;
+            m_SuperPutty = superPutty;
             InitializeComponent();
 
             // disable file transfers if pscp isn't configured.
@@ -175,39 +177,7 @@ namespace SuperPutty
             if (treeView1.SelectedNode.ImageIndex > 0)
             {
                 SessionData sessionData = (SessionData)treeView1.SelectedNode.Tag;
-                ctlPuttyPanel sessionPanel = null;
-
-                // This is the callback fired when the panel containing the terminal is closed
-                // We use this to save the last docking location
-                PuttyClosedCallback callback = delegate(bool closed)
-                {
-                    if (sessionPanel != null)
-                    {
-                        // save the last dockstate (if it has been changed)
-                        if (sessionData.LastDockstate != sessionPanel.DockState
-                            && sessionPanel.DockState != DockState.Unknown
-                            && sessionPanel.DockState != DockState.Hidden)
-                        {
-                            sessionData.LastDockstate = sessionPanel.DockState;
-                            sessionData.SaveToRegistry();
-                        }
-
-                        if (sessionPanel.InvokeRequired)
-                        {
-                            this.BeginInvoke((MethodInvoker)delegate()
-                            {
-                                sessionPanel.Close();
-                            });
-                        }
-                        else
-                        {
-                            sessionPanel.Close();
-                        }
-                    }
-                };
-
-                sessionPanel = new ctlPuttyPanel(sessionData, callback);
-                sessionPanel.Show(m_DockPanel, sessionData.LastDockstate);
+                m_SuperPutty.CreatePuttyPanel(sessionData);
             }
         }
 

--- a/SuperPutty/SessionTreeview.cs
+++ b/SuperPutty/SessionTreeview.cs
@@ -123,7 +123,7 @@ namespace SuperPutty
                         session.Host = (string)sessionKey.GetValue("HostName", "");
                         session.Port = (int)sessionKey.GetValue("PortNUmber", 22);
                         session.Proto = (ConnectionProtocol)Enum.Parse(typeof(ConnectionProtocol),
-                            ((string)sessionKey.GetValue("Proto", "SSH")).ToUpper());
+                            (string)sessionKey.GetValue("Protocol", "SSH"), true);
                         session.PuttySession = (string)sessionKey.GetValue("PuttySession", HttpUtility.UrlDecode(keyName));
                         session.SessionName = HttpUtility.UrlDecode(keyName);
                         session.Username = (string)sessionKey.GetValue("UserName", "");

--- a/SuperPutty/ctlPuttyPanel.Designer.cs
+++ b/SuperPutty/ctlPuttyPanel.Designer.cs
@@ -56,7 +56,7 @@
             this.aboutPuttyToolStripMenuItem});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
             this.contextMenuStrip1.ShowImageMargin = false;
-            this.contextMenuStrip1.Size = new System.Drawing.Size(142, 154);
+            this.contextMenuStrip1.Size = new System.Drawing.Size(142, 176);
             // 
             // newSessionToolStripMenuItem
             // 
@@ -69,6 +69,7 @@
             this.duplicateSessionToolStripMenuItem.Name = "duplicateSessionToolStripMenuItem";
             this.duplicateSessionToolStripMenuItem.Size = new System.Drawing.Size(141, 22);
             this.duplicateSessionToolStripMenuItem.Text = "Duplicate Session";
+            this.duplicateSessionToolStripMenuItem.Click += new System.EventHandler(this.duplicateSessionToolStripMenuItem_Click);
             // 
             // toolStripSeparator3
             // 

--- a/SuperPutty/ctlPuttyPanel.cs
+++ b/SuperPutty/ctlPuttyPanel.cs
@@ -38,14 +38,16 @@ namespace SuperPutty
         private ApplicationPanel applicationwrapper1;
         private SessionData m_Session;
         private PuttyClosedCallback m_ApplicationExit;
+        private frmSuperPutty m_SuperPutty;
 
         public string ApplicationTitle
         {
         	get { return this.applicationwrapper1.ApplicationWindowTitle; }
         }
 
-        public ctlPuttyPanel(SessionData session, PuttyClosedCallback callback)
+        public ctlPuttyPanel(frmSuperPutty superPutty, SessionData session, PuttyClosedCallback callback)
         {
+            m_SuperPutty = superPutty;
             m_Session = session;
             m_ApplicationExit = callback;
 
@@ -87,6 +89,12 @@ namespace SuperPutty
             this.Close();
         }
 
+        private void duplicateSessionToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            SessionData sessionData = new SessionData(m_Session);
+            m_SuperPutty.CreatePuttyPanel(sessionData);
+        }
+
         /// <summary>
         /// Reset the focus to the child application window
         /// </summary>
@@ -94,5 +102,6 @@ namespace SuperPutty
         {
             this.applicationwrapper1.ReFocusPuTTY();         
         }
+
     }
 }

--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -118,7 +118,7 @@ namespace SuperPutty
             /* 
              * Open the session treeview and dock it on the right
              */
-            m_Sessions = new SessionTreeview(dockPanel1);
+            m_Sessions = new SessionTreeview(this, dockPanel1);
             m_Sessions.Show(dockPanel1, WeifenLuo.WinFormsUI.Docking.DockState.DockRight);
 
             /*
@@ -396,7 +396,7 @@ namespace SuperPutty
                 }
             };
 
-            sessionPanel = new ctlPuttyPanel(sessionData, callback);
+            sessionPanel = new ctlPuttyPanel(this, sessionData, callback);
             sessionPanel.Show(dockPanel1, sessionData.LastDockstate);
         }
 


### PR DESCRIPTION
1) I fixed a bug in the 'Import Putty Sessions' code where it wasn't reading the right registry key which resulted in all sessions being SSH (I have a couple of Telnet sessions).

2) Added a 'Duplicate Session' feature to the button, where previously it did nothing. To do this, I had to consolidate the construction of PuttyPanels by letting the frmSuperPutty class handle it.

Ben
